### PR TITLE
Update drive to 0.3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ cd ~/gdrive
 drive pull
 ```
 
-__Note__: By default, the version `0.3.5` will be used. To change the version, define the `TAG` before the command:
+__Note__: By default, the version `0.3.8` will be used. To change the version, define the `TAG` before the command:
 
 ```sh
 drive version
-# drive version: 0.3.5
+# drive version: 0.3.8
 # ...
 
 TAG="0.3.2" drive version

--- a/bin/build
+++ b/bin/build
@@ -1,4 +1,4 @@
 #!/bin/sh
 cd "`dirname "$0"`/../src"
 
-docker build -t ${IMAGE:-timonier/drive}:${TAG:-0.3.5} .
+docker build -t ${IMAGE:-timonier/drive}:${TAG:-0.3.8} .

--- a/bin/drive
+++ b/bin/drive
@@ -15,4 +15,4 @@ docker run \
     -v "$PWD:$PWD" \
     -w "$PWD" \
     --rm \
-    ${IMAGE:-timonier/drive}:${TAG:-0.3.5} "$@"
+    ${IMAGE:-timonier/drive}:${TAG:-0.3.8} "$@"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.3
 MAINTAINER Morgan Auchede <morgan.auchede@gmail.com>
 
 ENV \
-    DRIVE_VERSION=0.3.5
+    DRIVE_VERSION=0.3.8
 
 RUN set -x \
 


### PR DESCRIPTION
Hi, 
I landed here from dockerhub because while trying to use the image I stumbled upon [this issue](https://github.com/odeke-em/drive/issues/764), which was solved in last version of drive. Hence this PR :).
BTW, have you tried contacting odeke-em to see if the docker image could be updated somehow without the manual sync between the two repos?
Also, I built the image locally and it worked, but let me know if I'm missing part of the pre-merging testing.
Thanks!
